### PR TITLE
Fix logrus package name change and missing name in NewWithAWSConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ logrus_firehose
 
 ```go
 import (
-    "github.com/Sirupsen/logrus"
+    "github.com/sirupsen/logrus"
     "github.com/beaubrewer/logrus_firehose"
 )
 
@@ -62,15 +62,16 @@ logrus_firehose
 
 ```go
 import (
-    "github.com/Sirupsen/logrus"
+    "github.com/sirupsen/logrus"
     "github.com/beaubrewer/logrus_firehose"
 )
 
 func main() {
-    hook, err := logrus_firehose.New("my_stream", Config{
+    hook, err := logrus_firehose.New("my_stream", logrus_firehose.Config{
         AccessKey: "ABC", // AWS accessKeyId
         SecretKey: "XYZ", // AWS secretAccessKey
         Region:    "us-west-2",
+        Endpoint:  "firehose.us-west-2.amazonaws.com",
     })
 
     // set custom fire level

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: d7aee050cdbaa2d639bd87980decda29980a157aeb58a4ee3626accb5278e4b2
-updated: 2017-03-01T11:19:13.312179454-07:00
+hash: 0a9b5da7df80f7d862008b4a96cd6492fbca016d655c2afe061008fd352d44a0
+updated: 2017-06-08T16:48:52.463031734-07:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 6669bce73b4e3bc922ff5ea3a3983ede26e02b39
+  version: c48c76c996d07c48cddab11a21971c299203d8c1
   subpackages:
   - aws
   - aws/awserr
@@ -20,6 +20,7 @@ imports:
   - aws/request
   - aws/session
   - aws/signer/v4
+  - internal/shareddefaults
   - private/protocol
   - private/protocol/json/jsonutil
   - private/protocol/jsonrpc
@@ -30,25 +31,17 @@ imports:
   - service/firehose
   - service/sts
 - name: github.com/go-ini/ini
-  version: c437d20015c2ab6454b7a66a13109ff0fb99e17a
+  version: d3de07a94d22b4a0972deb4b96d790c2c0ce8333
 - name: github.com/jmespath/go-jmespath
-  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
-- name: github.com/Sirupsen/logrus
-  version: 0208149b40d863d2c1a2f8fe5753096a9cf2cc8b
+  version: 3433f3ea46d9f8019119e7dd41274e112a2359a9
+- name: github.com/sirupsen/logrus
+  version: 202f25545ea4cf9b191ff7f846df5d87c9382c2b
 - name: golang.org/x/sys
-  version: e4594059fe4cde2daf423055a596c2cd1e6c9adf
+  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
   subpackages:
   - unix
 testImports:
-- name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
-  subpackages:
-  - spew
-- name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
-  subpackages:
-  - difflib
 - name: github.com/stretchr/testify
-  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  version: ""
   subpackages:
   - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/wildworks/logrus_firehose
 import:
-- package: github.com/Sirupsen/logrus
-  version: ^0.11.4
+- package: github.com/sirupsen/logrus
+  version: ^1.0.0
 - package: github.com/aws/aws-sdk-go
   version: ^1.7.3
   subpackages:

--- a/hook.go
+++ b/hook.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/firehose"
+	"github.com/sirupsen/logrus"
 )
 
 var defaultLevels = []logrus.Level{
@@ -59,10 +59,11 @@ func NewWithAWSConfig(name string, conf *aws.Config) (*FirehoseHook, error) {
 
 	svc := firehose.New(sess)
 	return &FirehoseHook{
-		client:       svc,
-		levels:       defaultLevels,
-		ignoreFields: make(map[string]struct{}),
-		filters:      make(map[string]func(interface{}) interface{}),
+		client:            svc,
+		defaultStreamName: name,
+		levels:            defaultLevels,
+		ignoreFields:      make(map[string]struct{}),
+		filters:           make(map[string]func(interface{}) interface{}),
 	}, nil
 }
 

--- a/hook_test.go
+++ b/hook_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
- logrus changed its name from upper case to lower case - fix it.
  https://github.com/sirupsen/logrus/issues/553

- NewWithAWSConfig was not passing on the name parameter.

- Minor fix in readme to use the Config value.